### PR TITLE
Remove unnecessary kafka package

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -45,7 +45,6 @@ default['mapr']['sysctl']['vm.overcommit_memory'] = 0
 default['mapr']['core']['packages'] = %w[
   mapr-core
   mapr-core-internal
-  mapr-kafka
 ]
 
 ### Zookeeper Attributes ###

--- a/spec/unit/recipes/core_spec.rb
+++ b/spec/unit/recipes/core_spec.rb
@@ -22,7 +22,6 @@ describe 'mapr::core' do
       expect(chef_run).to install_package(%w[
                                             mapr-core
                                             mapr-core-internal
-                                            mapr-kafka
                                           ],)
     end
   end


### PR DESCRIPTION
This package is not mandatory for bacis installation