### PR TITLE
One disk per storage for slow disk changes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -59,4 +59,4 @@ default['mapr']['nfs']['mount_options'] = %w[
 # Ex: %w[/dev/sdb /dev/sdc ...]
 default['mapr']['mfs']['config']['disks'] = %w[disk1 disk2 disk3]
 # Number of disks in a storage pool
-default['mapr']['mfs']['config']['stripe_width'] = 3
+default['mapr']['mfs']['config']['stripe_width'] = 1

--- a/spec/unit/recipes/disks_spec.rb
+++ b/spec/unit/recipes/disks_spec.rb
@@ -28,7 +28,7 @@ describe 'mapr::disks' do
     end
     it 'execute disksetup' do
       expect(chef_run).to run_execute('MapR disksetup format all disks')
-        .with(command: '/opt/mapr/server/disksetup -W 3 -F /tmp/disksetup_format_all_disks.txt')
+        .with(command: '/opt/mapr/server/disksetup -W 1 -F /tmp/disksetup_format_all_disks.txt')
     end
     it 'should execute the mapr request' do
       # TODO: Finish with the mapr version


### PR DESCRIPTION
In an environment where replacing failed disks can take months it is
better to only have one disk per storage pool.