### PR TITLE
Disable concurrency on travis CI tests due to bug

### DIFF
--- a/rakelib/55-kitchen.rake
+++ b/rakelib/55-kitchen.rake
@@ -5,16 +5,8 @@ task :test_kitchen do
   Kitchen.logger = Kitchen.default_file_logger
   @loader = Kitchen::Loader::YAML.new(project_config: './.kitchen.ec2.yml')
   config = Kitchen::Config.new(loader: @loader)
-  if ENV['KITCHEN_NO_CONCURRENCY']
-    config.instances.each do |instance|
-      instance.test(:always)
-    end
-  else
-    threads = []
-    config.instances.each do |instance|
-      threads << Thread.new { instance.test(:always) }
-    end
-    threads.map(&:join)
+  config.instances.each do |instance|
+    instance.test(:always)
   end
 end
 


### PR DESCRIPTION
https://github.com/inspec/kitchen-inspec/issues/167 leads to failures
when running tests in parallel so disable the concurrency.