### PR TITLE
disksetup - Only add new disks

### DIFF
--- a/recipes/disks.rb
+++ b/recipes/disks.rb
@@ -4,7 +4,7 @@
 #
 # Copyright:: 2018, The Authors, All Rights Reserved.
 
-mapr_disksetup 'format all disks' do
+mapr_disksetup 'configure new disks' do
   disks node['mapr']['mfs']['config']['disks'].sort
   stripe_width node['mapr']['mfs']['config']['stripe_width']
   opts %w[-W -F]

--- a/resources/disksetup.rb
+++ b/resources/disksetup.rb
@@ -4,7 +4,7 @@ property :stripe_width, Integer
 property :opts, Array
 
 load_current_value do |_new_resource|
-  configured_disks = ::Mapr::DiskSetup.configured_disks()
+  configured_disks = ::Mapr::DiskSetup.configured_disks
   if configured_disks
     disks configured_disks
   else
@@ -21,8 +21,10 @@ action :run do
 
     # Create tmpfile containing disks list
     diskfile = ::File.join('/tmp/', "disksetup_#{name.gsub(/ /, '_')}.txt")
+
+    disks_to_configure = disks - ::Mapr::DiskSetup.configured_disks
     file diskfile do
-      content disks.join("\n")
+      content disks_to_configure.join("/n")
     end
     cmd = ::Mapr::DiskSetup.build_command(opts, stripe_width, diskfile)
 

--- a/resources/disksetup.rb
+++ b/resources/disksetup.rb
@@ -24,7 +24,7 @@ action :run do
 
     disks_to_configure = disks - ::Mapr::DiskSetup.configured_disks
     file diskfile do
-      content disks_to_configure.join("/n")
+      content disks_to_configure.join("\n")
     end
     cmd = ::Mapr::DiskSetup.build_command(opts, stripe_width, diskfile)
 

--- a/spec/unit/recipes/disks_spec.rb
+++ b/spec/unit/recipes/disks_spec.rb
@@ -47,16 +47,16 @@ describe 'mapr::disks' do
     end
 
     it 'create diskfile' do
-      expect(chef_run).to render_file('/tmp/disksetup_format_all_disks.txt')
+      expect(chef_run).to render_file('/tmp/disksetup_configure_new_disks.txt')
         .with_content("#{disk3}\n#{disk2}\n#{disk0}\n")
     end
     it 'execute disksetup' do
-      expect(chef_run).to run_execute('MapR disksetup format all disks')
-        .with(command: '/opt/mapr/server/disksetup -W 1 -F /tmp/disksetup_format_all_disks.txt')
+      expect(chef_run).to run_execute('MapR disksetup configure new disks')
+        .with(command: '/opt/mapr/server/disksetup -W 1 -F /tmp/disksetup_configure_new_disks.txt')
     end
     it 'should execute the mapr request' do
       # TODO: Finish with the mapr version
-      expect(chef_run).to run_mapr_disksetup('format all disks')
+      expect(chef_run).to run_mapr_disksetup('configure new disks')
     end
   end
 end


### PR DESCRIPTION
Currently, When you add a new disk, it will try to re-format
all the disks already configured, which leads to disksetup error :
Error 17, File exists. Disk already added in disktab

Now, we will only run disksetup with a list of not configured disks